### PR TITLE
deps: Bump arrow,opendal,prost,chrono-tz,zstd to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,20 +32,20 @@ rust-version = "1.73"
 all-features = true
 
 [dependencies]
-arrow = { version = "52", features = ["prettyprint", "chrono-tz"] }
+arrow = { version = "53", features = ["prettyprint", "chrono-tz"] }
 bytemuck = { version = "1.18.0", features = ["must_cast"] }
 bytes = "1.4"
 chrono = { version = "0.4.37", default-features = false, features = ["std"] }
-chrono-tz = "0.9"
+chrono-tz = "0.10"
 fallible-streaming-iterator = { version = "0.1" }
 flate2 = "1"
 lz4_flex = "0.11"
 lzokay-native = "0.1"
 num = "0.4.1"
-prost = { version = "0.12" }
+prost = { version = "0.13" }
 snafu = "0.8"
 snap = "1.1"
-zstd = "0.12"
+zstd = "0.13"
 
 # async support
 async-trait = { version = "0.1.77", optional = true }
@@ -65,13 +65,13 @@ anyhow = { version = "1.0", optional = true }
 clap = { version = "4.5.4", features = ["derive"], optional = true }
 
 # opendal
-opendal = { version = "0.48", optional = true, default-features = false }
+opendal = { version = "0.50", optional = true, default-features = false }
 
 [dev-dependencies]
-arrow-ipc = { version = "52.0.0", features = ["lz4"] }
-arrow-json = "52.0.0"
+arrow-ipc = { version = "53.0.0", features = ["lz4"] }
+arrow-json = "53.0.0"
 criterion = { version = "0.5", default-features = false, features = ["async_tokio"] }
-opendal = { version = "0.48", default-features = false, features = ["services-memory"] }
+opendal = { version = "0.50", default-features = false, features = ["services-memory"] }
 pretty_assertions = "1.3.0"
 proptest = "1.0.0"
 serde_json = { version = "1.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
This PR will bump our dependences to latest.

cc @progval @WenyXu @waynexia for a review, thanks!