### PR TITLE
chore: Export array decoder so that users can access NaiveStripeDecoder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! writer.close().unwrap();
 //! ```
 
-mod array_decoder;
+pub mod array_decoder;
 pub mod arrow_reader;
 pub mod arrow_writer;
 #[cfg(feature = "async")]


### PR DESCRIPTION
Export `NaiveStripeDecoder` for public access.