### PR TITLE
chore: Expose StripeFactory so users can write them in struct

### DIFF
--- a/src/async_arrow_reader.rs
+++ b/src/async_arrow_reader.rs
@@ -68,7 +68,7 @@ impl<R: Send> From<Cursor<R>> for StripeFactory<R> {
     }
 }
 
-struct StripeFactory<R> {
+pub struct StripeFactory<R> {
     inner: Cursor<R>,
     is_end: bool,
 }
@@ -130,6 +130,11 @@ impl<R: AsyncChunkReader + 'static> ArrowStreamReader<R> {
             schema_ref,
             state: StreamState::Init,
         }
+    }
+
+    /// Extracts the inner `StripeFactory` and `SchemaRef` from the `ArrowStreamReader`.
+    pub fn into_parts(self) -> (Option<Box<StripeFactory<R>>>, SchemaRef) {
+        (self.factory, self.schema_ref)
     }
 
     pub fn schema(&self) -> SchemaRef {


### PR DESCRIPTION
This PR will expose `StripeFactory` so users can write in a struct like:

```rust
pub struct ORCSourceForCopy {
    table_ctx: Arc<dyn TableContext>,
    scan_progress: Arc<Progress>,
    op: Operator,
    reader: Option<(
        String,
        Box<StripeFactory<OrcChunkReader>>,
        HashableSchema,
        usize,
    )>,
}
```

I'm not sure if that's the best API we can have, maybe we can polish this part later.
