### PR TITLE
chore: Expose StripeFactory::read_next_stripe and Stripe::stream_map

### DIFF
--- a/src/async_arrow_reader.rs
+++ b/src/async_arrow_reader.rs
@@ -95,7 +95,8 @@ impl<R: AsyncChunkReader + 'static> StripeFactory<R> {
         .await
     }
 
-    async fn read_next_stripe(mut self) -> Result<(Self, Option<Stripe>)> {
+    /// Read the next stripe from the file.
+    pub async fn read_next_stripe(mut self) -> Result<(Self, Option<Stripe>)> {
         let info = self
             .inner
             .file_metadata

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -284,7 +284,7 @@ impl FallibleStreamingIterator for DecompressorIter {
 }
 
 /// A [`Read`]er fulfilling the ORC specification of reading compressed data.
-pub(crate) struct Decompressor {
+pub struct Decompressor {
     decompressor: DecompressorIter,
     offset: usize,
     is_first: bool,

--- a/src/stripe.rs
+++ b/src/stripe.rs
@@ -235,7 +235,8 @@ impl Stripe {
         self.number_of_rows
     }
 
-    pub(crate) fn stream_map(&self) -> &StreamMap {
+    /// Fetch the stream map
+    pub fn stream_map(&self) -> &StreamMap {
         &self.stream_map
     }
 
@@ -249,7 +250,7 @@ impl Stripe {
 }
 
 #[derive(Debug)]
-pub(crate) struct StreamMap {
+pub struct StreamMap {
     pub inner: HashMap<(u32, Kind), Bytes>,
     pub compression: Option<Compression>,
 }


### PR DESCRIPTION
This PR will expose `StripeFactory::read_next_stripe` and `Stripe::stream_map`

For discussion: https://github.com/datafusion-contrib/orc-rust/issues/11