### PR TITLE
Fix arrow version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-version = "1.73"
 all-features = true
 
 [dependencies]
-arrow = { version = "53", features = ["prettyprint", "chrono-tz"] }
+arrow = { version = "53.1.0", features = ["prettyprint", "chrono-tz"] }
 bytemuck = { version = "1.18.0", features = ["must_cast"] }
 bytes = "1.4"
 chrono = { version = "0.4.37", default-features = false, features = ["std"] }


### PR DESCRIPTION
Building with arrow 53.0.0 fails with:

```
error[E0277]: the trait bound `arrow::buffer::Buffer: From<Vec<u8>>` is not satisfied
   --> /home/dev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/orc-rust-0.5.0/src/array_decoder/string.rs:133:21
    |
133 |         let bytes = Buffer::from(bytes);
    |                     ^^^^^^ the trait `From<Vec<u8>>` is not implemented for `arrow::buffer::Buffer`
```