### PR TITLE
Various refactoring

### DIFF
--- a/src/array_decoder/list.rs
+++ b/src/array_decoder/list.rs
@@ -24,7 +24,7 @@ use snafu::ResultExt;
 
 use crate::array_decoder::derive_present_vec;
 use crate::column::Column;
-use crate::encoding::integer::get_unsigned_rle_reader;
+use crate::encoding::integer::get_unsigned_int_decoder;
 use crate::encoding::PrimitiveValueDecoder;
 use crate::proto::stream::Kind;
 
@@ -48,7 +48,7 @@ impl ListArrayDecoder {
         let inner = array_decoder_factory(child, field.clone(), stripe)?;
 
         let reader = stripe.stream_map().get(column, Kind::Length);
-        let lengths = get_unsigned_rle_reader(column, reader);
+        let lengths = get_unsigned_int_decoder(reader, column.rle_version());
 
         Ok(Self {
             inner,

--- a/src/array_decoder/list.rs
+++ b/src/array_decoder/list.rs
@@ -45,7 +45,7 @@ impl ListArrayDecoder {
         let present = PresentDecoder::from_stripe(stripe, column);
 
         let child = &column.children()[0];
-        let inner = array_decoder_factory(child, field.clone(), stripe)?;
+        let inner = array_decoder_factory(child, field.data_type(), stripe)?;
 
         let reader = stripe.stream_map().get(column, Kind::Length);
         let lengths = get_unsigned_int_decoder(reader, column.rle_version());

--- a/src/array_decoder/map.rs
+++ b/src/array_decoder/map.rs
@@ -50,10 +50,10 @@ impl MapArrayDecoder {
         let present = PresentDecoder::from_stripe(stripe, column);
 
         let keys_column = &column.children()[0];
-        let keys = array_decoder_factory(keys_column, keys_field.clone(), stripe)?;
+        let keys = array_decoder_factory(keys_column, keys_field.data_type(), stripe)?;
 
         let values_column = &column.children()[1];
-        let values = array_decoder_factory(values_column, values_field.clone(), stripe)?;
+        let values = array_decoder_factory(values_column, values_field.data_type(), stripe)?;
 
         let reader = stripe.stream_map().get(column, Kind::Length);
         let lengths = get_unsigned_int_decoder(reader, column.rle_version());

--- a/src/array_decoder/map.rs
+++ b/src/array_decoder/map.rs
@@ -24,7 +24,7 @@ use snafu::ResultExt;
 
 use crate::array_decoder::derive_present_vec;
 use crate::column::Column;
-use crate::encoding::integer::get_unsigned_rle_reader;
+use crate::encoding::integer::get_unsigned_int_decoder;
 use crate::encoding::PrimitiveValueDecoder;
 use crate::error::{ArrowSnafu, Result};
 use crate::proto::stream::Kind;
@@ -56,7 +56,7 @@ impl MapArrayDecoder {
         let values = array_decoder_factory(values_column, values_field.clone(), stripe)?;
 
         let reader = stripe.stream_map().get(column, Kind::Length);
-        let lengths = get_unsigned_rle_reader(column, reader);
+        let lengths = get_unsigned_int_decoder(reader, column.rle_version());
 
         let fields = Fields::from(vec![keys_field, values_field]);
 

--- a/src/array_decoder/mod.rs
+++ b/src/array_decoder/mod.rs
@@ -32,7 +32,7 @@ use crate::column::Column;
 use crate::encoding::boolean::BooleanDecoder;
 use crate::encoding::byte::ByteRleDecoder;
 use crate::encoding::float::FloatDecoder;
-use crate::encoding::integer::get_rle_reader;
+use crate::encoding::integer::get_signed_int_decoder;
 use crate::encoding::PrimitiveValueDecoder;
 use crate::error::{
     self, MismatchedSchemaSnafu, Result, UnexpectedSnafu, UnsupportedTypeVariantSnafu,
@@ -277,19 +277,19 @@ pub fn array_decoder_factory(
         }
         (DataType::Short { .. }, ArrowDataType::Int16) => {
             let iter = stripe.stream_map().get(column, Kind::Data);
-            let iter = get_rle_reader(column, iter)?;
+            let iter = get_signed_int_decoder(iter, column.rle_version());
             let present = PresentDecoder::from_stripe(stripe, column);
             Box::new(Int16ArrayDecoder::new(iter, present))
         }
         (DataType::Int { .. }, ArrowDataType::Int32) => {
             let iter = stripe.stream_map().get(column, Kind::Data);
-            let iter = get_rle_reader(column, iter)?;
+            let iter = get_signed_int_decoder(iter, column.rle_version());
             let present = PresentDecoder::from_stripe(stripe, column);
             Box::new(Int32ArrayDecoder::new(iter, present))
         }
         (DataType::Long { .. }, ArrowDataType::Int64) => {
             let iter = stripe.stream_map().get(column, Kind::Data);
-            let iter = get_rle_reader(column, iter)?;
+            let iter = get_signed_int_decoder(iter, column.rle_version());
             let present = PresentDecoder::from_stripe(stripe, column);
             Box::new(Int64ArrayDecoder::new(iter, present))
         }
@@ -315,7 +315,7 @@ pub fn array_decoder_factory(
             },
             ArrowDataType::Decimal128(a_precision, a_scale),
         ) if *precision as u8 == *a_precision && *scale as i8 == *a_scale => {
-            new_decimal_decoder(column, stripe, *precision, *scale)?
+            new_decimal_decoder(column, stripe, *precision, *scale)
         }
         (DataType::Timestamp { .. }, field_type) => {
             new_timestamp_decoder(column, field_type.clone(), stripe)?
@@ -326,7 +326,7 @@ pub fn array_decoder_factory(
         (DataType::Date { .. }, ArrowDataType::Date32) => {
             // TODO: allow Date64
             let iter = stripe.stream_map().get(column, Kind::Data);
-            let iter = get_rle_reader(column, iter)?;
+            let iter = get_signed_int_decoder(iter, column.rle_version());
             let present = PresentDecoder::from_stripe(stripe, column);
             Box::new(DateArrayDecoder::new(iter, present))
         }

--- a/src/array_decoder/struct_decoder.rs
+++ b/src/array_decoder/struct_decoder.rs
@@ -43,8 +43,8 @@ impl StructArrayDecoder {
         let decoders = column
             .children()
             .iter()
-            .zip(fields.iter().cloned())
-            .map(|(child, field)| array_decoder_factory(child, field, stripe))
+            .zip(fields.iter())
+            .map(|(child, field)| array_decoder_factory(child, field.data_type(), stripe))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {

--- a/src/array_decoder/union.rs
+++ b/src/array_decoder/union.rs
@@ -53,7 +53,7 @@ impl UnionArrayDecoder {
             .children()
             .iter()
             .zip(fields.iter())
-            .map(|(child, (_id, field))| array_decoder_factory(child, field.clone(), stripe))
+            .map(|(child, (_, field))| array_decoder_factory(child, field.data_type(), stripe))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {

--- a/src/column.rs
+++ b/src/column.rs
@@ -17,13 +17,8 @@
 
 use std::sync::Arc;
 
-use bytes::Bytes;
-use snafu::ResultExt;
-
 use crate::encoding::integer::RleVersion;
-use crate::error::{IoSnafu, Result};
 use crate::proto::{column_encoding::Kind as ProtoColumnKind, ColumnEncoding, StripeFooter};
-use crate::reader::ChunkReader;
 use crate::schema::DataType;
 
 #[derive(Clone, Debug)]
@@ -134,18 +129,5 @@ impl Column {
                     .collect()
             }
         }
-    }
-
-    pub fn read_stream<R: ChunkReader>(reader: &mut R, start: u64, length: u64) -> Result<Bytes> {
-        reader.get_bytes(start, length).context(IoSnafu)
-    }
-
-    #[cfg(feature = "async")]
-    pub async fn read_stream_async<R: crate::reader::AsyncChunkReader>(
-        reader: &mut R,
-        start: u64,
-        length: u64,
-    ) -> Result<Bytes> {
-        reader.get_bytes(start, length).await.context(IoSnafu)
     }
 }

--- a/src/column.rs
+++ b/src/column.rs
@@ -29,11 +29,11 @@ pub struct Column {
 }
 
 impl Column {
-    pub fn new(name: &str, data_type: &DataType, footer: &Arc<StripeFooter>) -> Self {
+    pub fn new(name: String, data_type: DataType, footer: Arc<StripeFooter>) -> Self {
         Self {
-            footer: footer.clone(),
-            data_type: data_type.clone(),
-            name: name.to_string(),
+            footer,
+            data_type,
+            name,
         }
     }
 

--- a/src/encoding/integer/mod.rs
+++ b/src/encoding/integer/mod.rs
@@ -210,10 +210,9 @@ impl VarintSerde for i128 {
     }
 }
 
-// We only implement for i16, i32, i64 and u64.
+// We only implement for i16, i32 and i64.
 // ORC supports only signed Short, Integer and Long types for its integer types,
-// and i8 is encoded as bytes. u64 is used for other encodings such as Strings
-// (to encode length, etc.).
+// and i8 is encoded as bytes.
 
 impl NInt for i16 {
     type Bytes = [u8; 2];

--- a/src/encoding/integer/mod.rs
+++ b/src/encoding/integer/mod.rs
@@ -31,11 +31,7 @@ use util::{
     get_closest_aligned_bit_width, signed_msb_decode, signed_zigzag_decode, signed_zigzag_encode,
 };
 
-use crate::{
-    column::Column,
-    error::{InvalidColumnEncodingSnafu, IoSnafu, Result},
-    proto::column_encoding::Kind as ProtoColumnKind,
-};
+use crate::error::{IoSnafu, Result};
 
 use super::PrimitiveValueDecoder;
 
@@ -46,34 +42,29 @@ mod util;
 // TODO: consider having a separate varint.rs
 pub use util::read_varint_zigzagged;
 
-pub fn get_unsigned_rle_reader<R: Read + Send + 'static>(
-    column: &Column,
-    reader: R,
-) -> Box<dyn PrimitiveValueDecoder<i64> + Send> {
-    match column.encoding().kind() {
-        ProtoColumnKind::Direct | ProtoColumnKind::Dictionary => {
-            Box::new(RleV1Decoder::<i64, _, UnsignedEncoding>::new(reader))
-        }
-        ProtoColumnKind::DirectV2 | ProtoColumnKind::DictionaryV2 => {
-            Box::new(RleV2Decoder::<i64, _, UnsignedEncoding>::new(reader))
-        }
+#[derive(Debug, Clone, Copy)]
+pub enum RleVersion {
+    V1,
+    V2,
+}
+
+pub fn get_signed_int_decoder<N: NInt>(
+    reader: impl Read + Send + 'static,
+    rle_version: RleVersion,
+) -> Box<dyn PrimitiveValueDecoder<N> + Send> {
+    match rle_version {
+        RleVersion::V1 => Box::new(RleV1Decoder::<N, _, SignedEncoding>::new(reader)),
+        RleVersion::V2 => Box::new(RleV2Decoder::<N, _, SignedEncoding>::new(reader)),
     }
 }
 
-pub fn get_rle_reader<N: NInt, R: Read + Send + 'static>(
-    column: &Column,
-    reader: R,
-) -> Result<Box<dyn PrimitiveValueDecoder<N> + Send>> {
-    match column.encoding().kind() {
-        ProtoColumnKind::Direct => Ok(Box::new(RleV1Decoder::<N, _, SignedEncoding>::new(reader))),
-        ProtoColumnKind::DirectV2 => {
-            Ok(Box::new(RleV2Decoder::<N, _, SignedEncoding>::new(reader)))
-        }
-        k => InvalidColumnEncodingSnafu {
-            name: column.name(),
-            encoding: k,
-        }
-        .fail(),
+pub fn get_unsigned_int_decoder<N: NInt>(
+    reader: impl Read + Send + 'static,
+    rle_version: RleVersion,
+) -> Box<dyn PrimitiveValueDecoder<N> + Send> {
+    match rle_version {
+        RleVersion::V1 => Box::new(RleV1Decoder::<N, _, UnsignedEncoding>::new(reader)),
+        RleVersion::V2 => Box::new(RleV2Decoder::<N, _, UnsignedEncoding>::new(reader)),
     }
 }
 

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -33,10 +33,7 @@ mod util;
 
 /// Encodes primitive values into an internal buffer, usually with a specialized run length
 /// encoding for better compression.
-pub trait PrimitiveValueEncoder<V>: EstimateMemory
-where
-    V: Copy,
-{
+pub trait PrimitiveValueEncoder<V: Copy>: EstimateMemory {
     fn new() -> Self;
 
     fn write_one(&mut self, value: V);

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,6 @@ use arrow::error::ArrowError;
 use snafu::prelude::*;
 use snafu::Location;
 
-use crate::proto;
 use crate::schema::DataType;
 
 // TODO: consolidate error types? better to have a smaller set?
@@ -101,14 +100,6 @@ pub enum OrcError {
         location: Location,
         orc_type: DataType,
         arrow_type: ArrowDataType,
-    },
-
-    #[snafu(display("Invalid encoding for column '{}': {:?}", name, encoding))]
-    InvalidColumnEncoding {
-        #[snafu(implicit)]
-        location: Location,
-        name: String,
-        encoding: proto::column_encoding::Kind,
     },
 
     #[snafu(display("Failed to convert to record batch: {}", source))]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -41,6 +41,7 @@ use arrow::datatypes::{DataType as ArrowDataType, Field, Schema, TimeUnit, Union
 #[derive(Debug, Clone)]
 pub struct RootDataType {
     children: Vec<NamedColumn>,
+    all_children: HashSet<usize>,
 }
 
 impl RootDataType {
@@ -52,6 +53,12 @@ impl RootDataType {
     /// Base columns of the file.
     pub fn children(&self) -> &[NamedColumn] {
         &self.children
+    }
+
+    /// If specified column index is one of the projected columns in this root data type,
+    /// considering transitive children of compound types.
+    pub fn contains_column_index(&self, index: usize) -> bool {
+        self.all_children.contains(&index)
     }
 
     /// Convert into an Arrow schema.
@@ -76,14 +83,22 @@ impl RootDataType {
             .filter(|col| mask.is_index_projected(col.data_type().column_index()))
             .map(|col| col.to_owned())
             .collect::<Vec<_>>();
-        Self { children }
+        let all_children = get_all_children_indices_set(&children);
+        Self {
+            children,
+            all_children,
+        }
     }
 
     /// Construct from protobuf types.
     pub(crate) fn from_proto(types: &[proto::Type]) -> Result<Self> {
         ensure!(!types.is_empty(), NoTypesSnafu {});
         let children = parse_struct_children_from_proto(types, 0)?;
-        Ok(Self { children })
+        let all_children = get_all_children_indices_set(&children);
+        Ok(Self {
+            children,
+            all_children,
+        })
     }
 }
 
@@ -95,6 +110,13 @@ impl Display for RootDataType {
         }
         Ok(())
     }
+}
+
+fn get_all_children_indices_set(columns: &[NamedColumn]) -> HashSet<usize> {
+    let mut set = HashSet::new();
+    set.insert(0);
+    set.extend(columns.iter().flat_map(|c| c.data_type().all_indices()));
+    set
 }
 
 #[derive(Debug, Clone)]
@@ -285,18 +307,17 @@ impl DataType {
             | DataType::Date { .. } => vec![],
             DataType::Struct { children, .. } => children
                 .iter()
-                .flat_map(|col| col.data_type().children_indices())
+                .flat_map(|col| col.data_type().all_indices())
                 .collect(),
             DataType::List { child, .. } => child.all_indices(),
             DataType::Map { key, value, .. } => {
-                let mut indices = key.children_indices();
-                indices.extend(value.children_indices());
+                let mut indices = key.all_indices();
+                indices.extend(value.all_indices());
                 indices
             }
-            DataType::Union { variants, .. } => variants
-                .iter()
-                .flat_map(|dt| dt.children_indices())
-                .collect(),
+            DataType::Union { variants, .. } => {
+                variants.iter().flat_map(|dt| dt.all_indices()).collect()
+            }
         }
     }
 

--- a/src/stripe.rs
+++ b/src/stripe.rs
@@ -154,7 +154,7 @@ impl Stripe {
             let column_id = stream.column();
             if column_ids.contains(&column_id) {
                 let kind = stream.kind();
-                let data = Column::read_stream(reader, stream_offset, length)?;
+                let data = reader.get_bytes(stream_offset, length).context(IoSnafu)?;
                 stream_map.insert((column_id, kind), data);
             }
             stream_offset += length;
@@ -207,7 +207,10 @@ impl Stripe {
             let column_id = stream.column();
             if column_ids.contains(&column_id) {
                 let kind = stream.kind();
-                let data = Column::read_stream_async(reader, stream_offset, length).await?;
+                let data = reader
+                    .get_bytes(stream_offset, length)
+                    .await
+                    .context(IoSnafu)?;
                 stream_map.insert((column_id, kind), data);
             }
 


### PR DESCRIPTION
Can see the commits for details of the individual refactors which have been grouped into this PR.

Mainly focusing on refactoring stripe/column related code, to ideally aim for:

- Unification of structs/enums with writer versions
- Move away from exposing proto types in API (prefer to have our own types which then map to proto)