### PR TITLE
chore: prepare release 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "orc-rust"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 homepage = "https://github.com/datafusion-contrib/orc-rust"
 repository = "https://github.com/datafusion-contrib/orc-rust"


### PR DESCRIPTION
Closes #41 