### PR TITLE
Require chrono < 0.4.40 to be consistent with Arrow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 arrow = { version = "53.1.0", features = ["prettyprint", "chrono-tz"] }
 bytemuck = { version = "1.18.0", features = ["must_cast"] }
 bytes = "1.4"
-chrono = { version = "0.4.37", default-features = false, features = ["std"] }
+chrono = { version = ">= 0.4.37, < 0.4.40", default-features = false, features = ["std"] }
 chrono-tz = "0.10"
 fallible-streaming-iterator = { version = "0.1" }
 flate2 = "1"


### PR DESCRIPTION
Arrow 53.4.1 added this requirement because chrono shipped a breaking update.

However, Cargo still tries to install the latest chrono as a dependency of orc-rust, which 1. keeps the broken chrono version  2. prevents installing the latest Arrow version.