### PR TITLE
allow Unicode-3.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,6 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "CC0-1.0",
-  "Unicode-DFS-2016",
   "Unicode-3.0",
 ]
 version = 2

--- a/deny.toml
+++ b/deny.toml
@@ -23,8 +23,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "CC0-1.0",
-]
-exceptions = [
-  { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+  "Unicode-DFS-2016",
+  "Unicode-3.0",
 ]
 version = 2


### PR DESCRIPTION
According to "ASF 3rd Party License Policy [Category A: What can we include in an ASF Project](https://www.apache.org/legal/resolved.html#category-a)", The [UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE](http://www.unicode.org/copyright.html#Exhibit1) is allowed to be included. And `Unicode-3.0` is one of those from the link. Screenshots below:

![image](https://github.com/user-attachments/assets/5c91fd90-03ba-47b7-aedb-136d0d805e8f)

![image](https://github.com/user-attachments/assets/82294a9a-a5ea-4885-a10b-da319202257f)

I also removed `Unicode-DFS-2016` because it doesn't occur.