### PR TITLE
chore: fix clippy warnings surfaced by Rust 1.95

### DIFF
--- a/src/encoding/integer/rle_v2/delta.rs
+++ b/src/encoding/integer/rle_v2/delta.rs
@@ -250,10 +250,8 @@ mod tests {
         .unwrap();
 
         let mut expected = vec![0, 10];
-        let mut i = 1;
-        for d in deltas {
-            expected.push(d + expected[i]);
-            i += 1;
+        for (i, d) in deltas.into_iter().enumerate() {
+            expected.push(d + expected[i + 1]);
         }
         assert_eq!(expected, out);
     }
@@ -279,10 +277,8 @@ mod tests {
         .unwrap();
 
         let mut expected = vec![10_000, 9_999];
-        let mut i = 1;
-        for d in deltas {
-            expected.push(expected[i] - d);
-            i += 1;
+        for (i, d) in deltas.into_iter().enumerate() {
+            expected.push(expected[i + 1] - d);
         }
         assert_eq!(expected, out);
     }

--- a/src/row_index.rs
+++ b/src/row_index.rs
@@ -280,7 +280,7 @@ pub fn parse_stripe_row_indexes(
                 filters.len(),
                 column_id
             );
-            for (entry, bloom) in row_group_index.entries_mut().zip(filters.into_iter()) {
+            for (entry, bloom) in row_group_index.entries_mut().zip(filters) {
                 entry.bloom_filter = Some(bloom);
             }
         }


### PR DESCRIPTION
## Summary

Rust 1.95 / clippy 1.95 promoted two lints to warnings that now break CI on any PR because the workflow runs clippy with `-D warnings`:

- `clippy::useless_conversion` in `src/row_index.rs:283` — drop a redundant `.into_iter()` inside a `zip()` argument (`IntoIterator` is already accepted).
- `clippy::explicit_counter_loop` in `src/encoding/integer/rle_v2/delta.rs:254` and `:283` — rewrite two manual counter loops in the test module with `.enumerate()`.

No behaviour change. `main` is currently green only because the last push predates the Rust 1.95 release; any new PR (e.g. #82) now fails all three Clippy jobs on these pre-existing lines.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`

All three pass locally on Rust 1.95.0.